### PR TITLE
Fix animations on Android.

### DIFF
--- a/SimulCasterRenderer/CMakeLists.txt
+++ b/SimulCasterRenderer/CMakeLists.txt
@@ -3,6 +3,7 @@ project( SimulCasterRenderer )
 
 # Build options
 set(DEBUG_CONFIGURATIONS Debug)
+
 # Source
 set( src_root
 	src/Common.h
@@ -67,6 +68,11 @@ set( src_crossplatform
 	src/crossplatform/MemoryUtil.h
 	)
 
+set(src_testing
+	src/crossplatform/Tests.cpp
+	src/crossplatform/Tests.h
+	)
+
 #Include its root directory
 include_directories(src)
 #Include libavstream
@@ -86,7 +92,7 @@ elseif(ANDROID)
 	include_directories(../client/LibOVRKernel/Src)
 endif()
 
-set( src_public ${src_root} ${src_api} ${src_crossplatform} )
+set( src_public ${src_root} ${src_api} ${src_crossplatform} ${src_testing})
 message ( "src_public ${src_public}" )
 #source_group("src" src FILES ${src_root} )
 #source_group("src\\api" src FILES ${src_api} )

--- a/SimulCasterRenderer/src/crossplatform/Tests.cpp
+++ b/SimulCasterRenderer/src/crossplatform/Tests.cpp
@@ -1,0 +1,47 @@
+#include "Tests.h"
+
+#include "libavstream/common_maths.h"
+
+#include "Common.h"
+#include "Transform.h"
+
+namespace scr
+{
+	void Tests::RunAllTests()
+	{
+		RunConversionEquivalenceTests();
+	}
+
+	void Tests::RunConversionEquivalenceTests()
+	{
+		//Test conversions from Unity server.
+		RunConversionEquivalenceTest(avs::AxesStandard::UnityStyle, avs::AxesStandard::EngineeringStyle);
+		RunConversionEquivalenceTest(avs::AxesStandard::UnityStyle, avs::AxesStandard::GlStyle);
+	
+		//Test conversions from Unreal server.
+		RunConversionEquivalenceTest(avs::AxesStandard::UnrealStyle, avs::AxesStandard::EngineeringStyle);
+		RunConversionEquivalenceTest(avs::AxesStandard::UnrealStyle, avs::AxesStandard::GlStyle);
+	}
+
+	void Tests::RunConversionEquivalenceTest(avs::AxesStandard fromStandard, avs::AxesStandard toStandard)
+	{
+		avs::Transform transformAVS;
+		transformAVS.position = avs::vec3(1.0f, 2.0f, 3.0f);
+		transformAVS.rotation = avs::vec4(4.0f, 5.0f, 6.0f, 7.0f);
+		transformAVS.scale = avs::vec3(8.0f, 9.0f, 10.0f);
+
+		avs::Transform convertedTransformAVS(transformAVS);
+		avs::ConvertTransform(fromStandard, toStandard, convertedTransformAVS);
+
+		scr::Transform transformSCR(transformAVS);
+		scr::Transform convertedTransformSCR(convertedTransformAVS);
+
+		scr::mat4 matrix = transformSCR.GetTransformMatrix();
+		scr::mat4 convertedMatrix = avs::Mat4x4::convertToStandard(matrix, fromStandard, toStandard);
+
+		if(convertedMatrix != convertedTransformSCR.GetTransformMatrix())
+		{
+			SCR_CERR_BREAK("Test failure! Failed equivalence check between transform conversion and matrix conversion!", EPROTO)
+		}
+	}
+}

--- a/SimulCasterRenderer/src/crossplatform/Tests.h
+++ b/SimulCasterRenderer/src/crossplatform/Tests.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "libavstream/common_maths.h"
+
+namespace scr
+{
+	//Static class for testing logic; all tests should pass or there is a logic error that needs fixing.
+	class Tests
+	{
+	public:
+		//There should be no constructor for a static class.
+		Tests() = delete;
+
+		static void RunAllTests();
+
+		static void RunConversionEquivalenceTests();
+		static void RunConversionEquivalenceTest(avs::AxesStandard fromStandard, avs::AxesStandard toStandard);
+	};
+}

--- a/TeleportClient/basic_linear_algebra.h
+++ b/TeleportClient/basic_linear_algebra.h
@@ -428,6 +428,32 @@ namespace scr
 			);
 		}
 
+		bool operator==(const mat4& rhs) const
+		{
+			return
+				a == rhs.a &&
+				b == rhs.b &&
+				c == rhs.c &&
+				d == rhs.d &&
+				e == rhs.e &&
+				f == rhs.f &&
+				g == rhs.g &&
+				h == rhs.h &&
+				i == rhs.i &&
+				j == rhs.j &&
+				k == rhs.k &&
+				l == rhs.l &&
+				m == rhs.m &&
+				n == rhs.n &&
+				o == rhs.o &&
+				p == rhs.p;
+		}
+
+		bool operator!=(const mat4& rhs) const
+		{
+			return !(*this == rhs);
+		}
+
 		avs::vec3 GetTranslation() const
 		{
 			return avs::vec3(d, h, l);

--- a/client/TeleportVRQuestClient/Src/Application.h
+++ b/client/TeleportVRQuestClient/Src/Application.h
@@ -53,7 +53,6 @@ namespace OVRFW
 
 	class Application : public ovrAppl, public SessionCommandInterface, public DecodeEventInterface, public ClientAppInterface
 	{
-		const scr::quat HAND_ROTATION_DIFFERENCE {0.0000000456194194, 0.923879385, -0.382683367, 0.000000110135019}; //Adjustment to the controller's rotation to get the desired rotation.
 	public:
 		Application();
 		virtual ~Application();

--- a/client/TeleportVRQuestClient/Src/ClientRenderer.cpp
+++ b/client/TeleportVRQuestClient/Src/ClientRenderer.cpp
@@ -365,6 +365,7 @@ void ClientRenderer::EnteredVR(const ovrJava *java)
 
 	scr::ShaderResourceLayout shaderResourceLayout;
 	shaderResourceLayout.AddBinding(0, scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,scr::Shader::Stage::SHADER_STAGE_VERTEX);
+	shaderResourceLayout.AddBinding(1, scr::ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER,scr::Shader::Stage::SHADER_STAGE_VERTEX);
 	shaderResourceLayout.AddBinding(4, scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,scr::Shader::Stage::SHADER_STAGE_VERTEX);
 	shaderResourceLayout.AddBinding(2, scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,scr::Shader::Stage::SHADER_STAGE_VERTEX);
 
@@ -380,6 +381,7 @@ void ClientRenderer::EnteredVR(const ovrJava *java)
 
 	scr::ShaderResource pbrShaderResource(shaderResourceLayout);
 	pbrShaderResource.AddBuffer(scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,0,"u_CameraData", {});
+	pbrShaderResource.AddBuffer(scr::ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER,1,"TagDataID", {});
 	pbrShaderResource.AddBuffer(scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,4,"u_BoneData", {});
 	pbrShaderResource.AddBuffer(scr::ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER,2,"u_MaterialData", {});
 	pbrShaderResource.AddImage(	scr::ShaderResourceLayout::ShaderResourceType::COMBINED_IMAGE_SAMPLER,10,"u_DiffuseTexture", {});
@@ -415,23 +417,20 @@ void ClientRenderer::EnteredVR(const ovrJava *java)
 
 	//Static passes.
 	pipelineCreateInfo.m_ShaderCreateInfo[0].entryPoint = "Static";
-	for(const std::string &p:passNames)
+	for(const std::string& passName : passNames)
 	{
-		std::string stat_name="Static_";
-		stat_name+=p;
-		pipelineCreateInfo.m_ShaderCreateInfo[1].entryPoint = p.c_str();
-		clientAppInterface->BuildEffectPass(stat_name.c_str(), &layout, &pipelineCreateInfo,
-											{pbrShaderResource});
+		std::string completeName = "Static_" + passName;
+		pipelineCreateInfo.m_ShaderCreateInfo[1].entryPoint = passName.c_str();
+		clientAppInterface->BuildEffectPass(completeName.c_str(), &layout, &pipelineCreateInfo, {pbrShaderResource});
 	}
+
 	//Skinned passes.
-	//pipelineCreateInfo.m_ShaderCreateInfo[0].entryPoint = "Animated";
-	for(const std::string &p:passNames)
+	pipelineCreateInfo.m_ShaderCreateInfo[0].entryPoint = "Animated";
+	for(const std::string& passName : passNames)
 	{
-		std::string stat_name="Animated_";
-		stat_name+=p;
-		pipelineCreateInfo.m_ShaderCreateInfo[1].entryPoint = p.c_str();
-		clientAppInterface->BuildEffectPass(stat_name.c_str(), &layout, &pipelineCreateInfo,
-											{pbrShaderResource});
+		std::string effectName = "Animated_" + passName;
+		pipelineCreateInfo.m_ShaderCreateInfo[1].entryPoint = passName.c_str();
+		clientAppInterface->BuildEffectPass(effectName.c_str(), &layout, &pipelineCreateInfo, {pbrShaderResource});
 	}
 }
 

--- a/client/TeleportVRQuestClient/Src/OVRNode.cpp
+++ b/client/TeleportVRQuestClient/Src/OVRNode.cpp
@@ -224,9 +224,9 @@ OVRFW::ovrSurfaceDef OVRNode::CreateOVRSurface(size_t materialIndex, std::shared
 	std::vector<const scr::ShaderResource*> pbrShaderResources;
 	pbrShaderResources.push_back(&globalGraphicsResources.scrCamera->GetShaderResource());
 	pbrShaderResources.push_back(&globalGraphicsResources.tagShaderResource);
+	pbrShaderResources.push_back(&(skin ? skin->GetShaderResource() : globalGraphicsResources.defaultSkin.GetShaderResource()));
 	pbrShaderResources.push_back(&material->GetShaderResource());
 	pbrShaderResources.push_back(&globalGraphicsResources.lightCubemapShaderResources);
-	pbrShaderResources.push_back(&(skin ? skin->GetShaderResource() : globalGraphicsResources.defaultSkin.GetShaderResource()));
 
 	//Set image samplers and uniform buffers.
 	size_t resourceCount = 0;

--- a/client/TeleportVRQuestClient/Src/SCR_Class_GL_Impl/GL_Effect.cpp
+++ b/client/TeleportVRQuestClient/Src/SCR_Class_GL_Impl/GL_Effect.cpp
@@ -169,9 +169,9 @@ ovrProgramParmType GL_Effect::ToOVRProgramParmType(ShaderResourceLayout::ShaderR
         case ShaderResourceLayout::ShaderResourceType::UNIFORM_TEXEL_BUFFER:     return ovrProgramParmType::MAX;
         case ShaderResourceLayout::ShaderResourceType::STORAGE_TEXEL_BUFFER:     return ovrProgramParmType::MAX;
         case ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER:           return ovrProgramParmType::BUFFER_UNIFORM;
-        case ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER:           return ovrProgramParmType::MAX;
+        case ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER:           return ovrProgramParmType::BUFFER_STORAGE;
         case ShaderResourceLayout::ShaderResourceType::UNIFORM_BUFFER_DYNAMIC:   return ovrProgramParmType::BUFFER_UNIFORM;
-        case ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER_DYNAMIC:   return ovrProgramParmType::MAX;
+        case ShaderResourceLayout::ShaderResourceType::STORAGE_BUFFER_DYNAMIC:   return ovrProgramParmType::BUFFER_STORAGE;
         case ShaderResourceLayout::ShaderResourceType::INPUT_ATTACHMENT:         return ovrProgramParmType::MAX;
 		default:
 			exit(1);

--- a/libavstream/include/libavstream/common_maths.h
+++ b/libavstream/include/libavstream/common_maths.h
@@ -435,9 +435,10 @@ namespace avs
 
 					break;
 				case::avs::AxesStandard::GlStyle:
+					convertedMatrix.m02 = -matrix.m02;
+					convertedMatrix.m12 = -matrix.m12;
 					convertedMatrix.m20 = -matrix.m20;
 					convertedMatrix.m21 = -matrix.m21;
-					convertedMatrix.m22 = -matrix.m22;
 					convertedMatrix.m23 = -matrix.m23;
 
 					break;
@@ -479,15 +480,15 @@ namespace avs
 					//ROTATION (Implicitly handles scale.):
 					convertedMatrix.m00 = matrix.m11;
 					convertedMatrix.m01 = matrix.m12;
-					convertedMatrix.m02 = matrix.m10;
+					convertedMatrix.m02 = -matrix.m10;
 
 					convertedMatrix.m10 = matrix.m21;
 					convertedMatrix.m11 = matrix.m22;
-					convertedMatrix.m12 = matrix.m20;
+					convertedMatrix.m12 = -matrix.m20;
 
 					convertedMatrix.m20 = -matrix.m01;
 					convertedMatrix.m21 = -matrix.m02;
-					convertedMatrix.m22 = -matrix.m00;
+					convertedMatrix.m22 = matrix.m00;
 
 					break;
 				default:

--- a/pc_client/ClientRenderer.cpp
+++ b/pc_client/ClientRenderer.cpp
@@ -31,6 +31,7 @@
 #include "crossplatform/Log.h"
 #include "crossplatform/SessionClient.h"
 #include "crossplatform/Light.h"
+#include "crossplatform/Tests.h"
 
 #include "SCR_Class_PC_Impl/PC_Texture.h"
 
@@ -126,6 +127,8 @@ ClientRenderer::ClientRenderer(ClientDeviceState *c):
 	//Initalise time stamping for state update.
 	platformStartTimestamp = avs::PlatformWindows::getTimestamp();
 	previousTimestamp = (uint32_t)avs::PlatformWindows::getTimeElapsed(platformStartTimestamp, avs::PlatformWindows::getTimestamp());
+
+	scr::Tests::RunAllTests();
 }
 
 ClientRenderer::~ClientRenderer()


### PR DESCRIPTION
+ Added Tests class to SimulCasterRenderer for testing logic; automated testing should help catch this issue when it happens again in the future, i.e. supporting negative scaling.
+ Run tests on start of PC client.
+ Added equality check to scr::mat4, however, it is susceptible to floating point error.
+ Now support storage buffers in GL_Effect::ToOVRProgramParmType(...).
# Re-enabled setting 'Animated' entry point for skinned meshes.
# Changed shader resources layout to include TagDataID storage buffer.
# Changed avs::Mat4x4::convertToStandard(...) to match ConvertTransform(...).
- Removed unused HAND_ROTATION_DIFFERENCE from Application.h.